### PR TITLE
RSS macros

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -12,5 +12,7 @@
 	   #:emit-simple-tags
 	   ;; RSS 2.0
 	   #:rss-channel-header
+	   #:with-rss-channel-header
 	   #:rss-item
+	   #:with-rss-item
 	   #:with-rss2))

--- a/rss2.lisp
+++ b/rss2.lisp
@@ -18,6 +18,24 @@
 			:url image
 			:link (or image-link link)))))
 
+(defmacro with-rss-channel-header ((title link &key description
+                                          (generator "xml-emitter")
+                                          (language "en-us")
+                                          image image-title image-link)
+                                   &body body)
+  `(progn
+     (emit-simple-tags :title ,title
+                       :link ,link
+                       :description ,description
+                       :generator ,generator
+                       :language ,language)
+     (when ,image
+       (with-tag ("image")
+         (emit-simple-tags :title (or ,image-title ,title)
+                           :url ,image
+                           :link (or ,image-link ,link))))
+     ,@body))
+
 (defun rss-item (title &key link description author category
 		 comments guid pubDate source)
   (with-tag ("item")
@@ -30,6 +48,21 @@
 		      :guid guid
 		      "pubDate" pubDate
 		      :source source)))
+
+(defmacro with-rss-item ((title &key link description author category
+                                comments guid pubDate source)
+                         &body body)
+  `(with-tag ("item")
+     (emit-simple-tags :title ,title
+                       :link ,link
+                       :description ,description
+                       :author ,author
+                       :category ,category
+                       :comments ,comments
+                       :guid ,guid
+                       "pubDate" ,pubDate
+                       :source ,source)
+     ,@body))
 
 (defmacro with-rss2 ((stream &key (encoding "ISO-8859-1")) &body body)
   `(with-xml-output (,stream :encoding ,encoding)

--- a/rss2.lisp
+++ b/rss2.lisp
@@ -6,11 +6,12 @@
 
 (in-package :xml-emitter)
 
-(defun rss-channel-header (title link &key description (language "en-us")
+(defun rss-channel-header (title link &key description (generator "xml-emitter") (language "en-us")
 		       image image-title image-link)
   (emit-simple-tags :title title
 		    :link link
 		    :description description
+		    :generator generator
 		    :language language)
   (when image
     (with-tag ("image")

--- a/rss2.lisp
+++ b/rss2.lisp
@@ -64,9 +64,9 @@
                        :source ,source)
      ,@body))
 
-(defmacro with-rss2 ((stream &key (encoding "ISO-8859-1")) &body body)
+(defmacro with-rss2 ((stream &key (encoding "ISO-8859-1") (attrs '(("version" "2.0")))) &body body)
   `(with-xml-output (,stream :encoding ,encoding)
-     (with-tag ("rss" '(("version" "2.0")))
+     (with-tag ("rss" ,attrs)
        (with-tag ("channel")
 	 ,@body))))
 

--- a/xml.lisp
+++ b/xml.lisp
@@ -86,6 +86,7 @@
   (write-char #\> *xml-output-stream*))
 
 (defun empty-tag (name &optional attrs namespace)
+  (fresh-line *xml-output-stream*)
   (start-tag name attrs namespace T))
 
 (defun end-tag (name)


### PR DESCRIPTION
This PR adds WITH-RSS-CHANNEL-HEADER and WITH-RSS-ITEM macros to the package API (well, it adds support for `<generator>` and fixes a format issue with EMPTY-TAG too, but these changes can be easily moved into a new PR if need be).

The argument in favor of these new macros is that it would make it easier for users to customize the generated XML; "easier", because currently, in case a missing support for a specific element, users are forced to either one of these:

- submit a bunch of PRs to add support for `<generator>`, or `<atom:link>`
- don't use WITH-RSS at all, and simply rely on low-level macros (the ones defined inside xml.lisp)

Few use cases this change will support.

# Support for `<guid isPermaLink></guid>` inside items

Without macros, you have to submit a PR in order to change RSS-ITEM to customize how `<guid>` gets created (e.g. https://github.com/VitoVan/xml-emitter/pull/3); with macros on the other hand, one could easily implement this on the application side:

```
      :do (xml-emitter:with-rss-item (date :link *link*
                                           :pubDate pub-date)
            (xml-emitter::simple-tag "guid" guid '(("isPermaLink" "false")))

```

# Support for `<atom:link>` with rel=self inside 

Without macros, you would have to submit a PR and change RSS-CHANNEL-HEADER to add an additional `<atom:link>` element; with macros instead, one could go with the following:

```
    (xml-emitter::with-rss-channel-header (*title* *link* :description (read-channel-description)
                                                          :generator *generator*
                                                          :image *image*)
      (xml-emitter::empty-tag "atom:link" `(("href" ,*atom-link-self*)
                                            ("rel" "self")
                                            ("type" "application/rss+xml"))))
```

# Wrapping elements inside CDATA blocks

Sometimes you need to wrap description fields inside `<![CDATA[...]]>` blocks to tell clients not to parse their content, and currently there is no easy way to support this (well, unless you exposed a way to let users specify wrap-pre/wrap-post strings, and changed the implementation to output these wrap-pre/wrap-post strings, as-is, before outputting the content of description); and what if you wanted to do something similar for other fields too?  Well, with macros, users can do deal with all this on their side:

```
      :do (xml-emitter:with-rss-item (date :link * :pubDate pub-date)
            (xml-emitter::simple-tag "guid" (format NIL "~a#~a" *link* date)
                                     '(("isPermaLink" "false")))
            (xml-emitter::with-simple-tag ("description")
              (xml-emitter::xml-as-is "<![CDATA[<pre>")
              (xml-emitter::xml-out (plan-day-content day))
              (xml-emitter::xml-as-is "</pre>]]>"))))))
```
